### PR TITLE
Append set-cookie header instead of replacing existing

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -118,7 +118,7 @@ export const sessionMiddleware = (options: SessionOptions) => {
 
     // Append constructed set-cookie headers to the response headers.
     headers.forEach((value, key) => {
-      resp.headers.set(key, value);
+      resp.headers.append(key, value);
     });
 
     return resp;

--- a/src/middleware_test.ts
+++ b/src/middleware_test.ts
@@ -255,7 +255,7 @@ describe("sessionMiddleware", () => {
             headers: new Headers([
               ["key1", "value1"],
               ["key2", "value2"],
-              ["set-cookie", "dummy=this_will_be_overwritten"],
+              ["set-cookie", "othercookie=somevalue"],
             ]),
           }),
       });
@@ -265,7 +265,10 @@ describe("sessionMiddleware", () => {
       assert(result.headers.has("key2"));
       assertEquals(result.headers.get("key2"), "value2");
       assert(result.headers.has("set-cookie"));
-      assertMatch(result.headers.get("set-cookie") as string, /^session=/);
+      const setCookieHeaders = result.headers.getSetCookie();
+      assertEquals(setCookieHeaders.length, 2);
+      assertEquals(setCookieHeaders[0], "othercookie=somevalue");
+      assertMatch(setCookieHeaders[1], /^session=/);
     });
   });
 });


### PR DESCRIPTION
A small bugfix: currently if the response already has another set-cookie header, it is lost.

Thanks a lot for creating this package! It's great to be able to transition away from deno.land/x/fresh_session and its outdated deps.