### PR TITLE
Improve types for Session data

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1,3 +1,9 @@
+/** Type for all values that may be serialized to JSON */
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+
+/** Interface for objects that may be serialized to JSON */
+interface JsonObject extends Record<string, JsonValue> {};
+
 /**
  * Session object to be stored in a storage and used as in-memory cache
  */
@@ -8,7 +14,7 @@ export interface SessionObject {
    * - value: The actual data to be stored.
    * - flash: A boolean indicating if the data should be removed after being read once.
    */
-  data: Record<string, { value: unknown; flash: boolean }>;
+  data: Record<string, { value: JsonValue; flash: boolean }>;
 
   /**
    * Expire type representing the expiration time of a session.
@@ -99,11 +105,11 @@ export class Session {
    * @param key Session data key.
    * @returns data for the key.
    */
-  get(key: string): unknown {
+  get<T extends JsonValue = JsonValue>(key: string): T | null {
     const entry = this.sessionObject.data[key];
 
     if (entry) {
-      const value = entry.value;
+      const value = entry.value as T;
       if (entry.flash) {
         delete this.sessionObject.data[key];
       }
@@ -120,7 +126,7 @@ export class Session {
    * @param key Session data key.
    * @param value Session data value.
    */
-  set(key: string, value: unknown) {
+  set(key: string, value: JsonValue) {
     this.sessionObject.data[key] = {
       value,
       flash: false,
@@ -133,7 +139,7 @@ export class Session {
    * @param key Session data key.
    * @param value Session data value.
    */
-  flash(key: string, value: unknown) {
+  flash(key: string, value: JsonValue) {
     this.sessionObject.data[key] = {
       value,
       flash: true,


### PR DESCRIPTION
Constrain the data to types that can serialised as JSON, and allow callers of `Session.get()` to provide an explicit type parameter to cast session data to the expected type. Example usage: `const value = session.get<number>("key");`
